### PR TITLE
Added support for a custom layout attributes class

### DIFF
--- a/TLLayoutTransitioning/TLTransitionLayout.m
+++ b/TLLayoutTransitioning/TLTransitionLayout.m
@@ -78,7 +78,8 @@
             
             UICollectionViewLayoutAttributes *fromPose = self.poseAtIndexPath ? [self.poseAtIndexPath objectForKey:key] : [self.currentLayout layoutAttributesForItemAtIndexPath:indexPath];
             UICollectionViewLayoutAttributes *toPose = reverse ? [self.currentLayout layoutAttributesForItemAtIndexPath:indexPath] : [self.nextLayout layoutAttributesForItemAtIndexPath:indexPath];
-            UICollectionViewLayoutAttributes *pose = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
+            UICollectionViewLayoutAttributes *pose = [[[self class] layoutAttributesClass]
+                                                      layoutAttributesForCellWithIndexPath:indexPath];
             
             CGFloat originX = f * fromPose.frame.origin.x + t * toPose.frame.origin.x;
             CGFloat originY = f * fromPose.frame.origin.y + t * toPose.frame.origin.y;


### PR DESCRIPTION
It is useful to be able to pass the progress, for example, to the cells during complex transitions. Previously the transition layout was using UICollectionViewLayoutAttributes by default instead of honouring the class defined by `layoutAttributesClass`
