### PR TITLE
Interpolation fix

### DIFF
--- a/TLLayoutTransitioning/TLTransitionLayout.m
+++ b/TLLayoutTransitioning/TLTransitionLayout.m
@@ -140,12 +140,15 @@
 
 - (void)interpolatePose:(UICollectionViewLayoutAttributes *)pose fromPose:(UICollectionViewLayoutAttributes *)fromPose toPose:(UICollectionViewLayoutAttributes *)toPose fromProgress:(CGFloat)f toProgress:(CGFloat)t
 {
-    CGRect frame = CGRectZero;
-    frame.origin.x = f * fromPose.frame.origin.x + t * toPose.frame.origin.x;
-    frame.origin.y = f * fromPose.frame.origin.y + t * toPose.frame.origin.y;
-    frame.size.width = f * fromPose.frame.size.width + t * toPose.frame.size.width;
-    frame.size.height = f * fromPose.frame.size.height + t * toPose.frame.size.height;
-    pose.frame = frame;
+    CGRect bounds = CGRectZero;
+    bounds.size.width = f * fromPose.bounds.size.width + t * toPose.bounds.size.width;
+    bounds.size.height = f * fromPose.bounds.size.height + t * toPose.bounds.size.height;
+    pose.frame = bounds;
+ 
+    CGPoint center = CGPointZero;
+    center.x = f * fromPose.center.x + t * toPose.center.x;
+    center.y = f * fromPose.center.y + t * toPose.center.y;
+    pose.center = center;
     
     pose.alpha = f * fromPose.alpha + t * toPose.alpha;
 


### PR DESCRIPTION
Hello Timothy. 
I have faced an issue with frame calculation in case of fromPose.transform.tx and toPose.transform.ty are non zero. The pose.frame, which is calculated in the interpolatePose: method, multiplies transform because of translations are already contained in fromPose.frame and toPose.frame.

You may find warning and workaround in apple's documentation: 
    
    However, if the transform property contains a non-identity transform, the value of the frame property is undefined and should not be modified. In that case, you can reposition the view using the center property and adjust the size using the bounds property instead.

This changeset fixes that issue by interpolating of bounds and center instead of frame.