### PR TITLE
Fix clang analyzer warning

### DIFF
--- a/TLLayoutTransitioning/UICollectionView+TLTransitioning.m
+++ b/TLLayoutTransitioning/UICollectionView+TLTransitioning.m
@@ -321,6 +321,7 @@ CGFloat transitionProgress(CGFloat initialValue, CGFloat currentValue,
             destinationPoint = CGPointMake(CGRectGetMaxX(placementFrame), CGRectGetMidY(placementFrame));
             break;
         default:
+            destinationPoint = CGPointZero;
             break;
     }
     


### PR DESCRIPTION
Fixes "The right operand of '-' is a garbage value" by ensuring the default case leaves destinationPoint assigned to something.